### PR TITLE
Implement Local installation for module

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Repository for development of the MLTDM Model
 ## Local Installation
 
 1. Clone repo or download zip
-2. In root directory: pip install -e .[options]
+2. In root directory: pip install -e .
 3. Create a local directory to hold model data, e.g., mltdm/local_data/
 4. Change the configuration file mltdm/mltdm.yaml such that the 'data_dir' variable points to the local directory created in step 3. File paths must be absolute, not relative.
 5. Run the model setup (see Notebooks/RF_predict.ipynb):

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # mltdm
 Repository for development of the MLTDM Model
 
-## mltdm yaml file
+## Local Installation
 
- - Configuration file for package
-     - All paths should be absolute
+1. Clone repo or download zip
+2. In root directory: pip install -e .[options]
+3. Create a local directory to hold model data, e.g., mltdm/local_data/
+4. Change the configuration file mltdm/mltdm.yaml such that the 'data_dir' variable points to the local directory created in step 3. File paths must be absolute, not relative.
+5. Run the model setup (see Notebooks/RF_predict.ipynb):
+
+> import mltdm.den_fx as den_fx
+> den_fx.setup()
+
+This will take a few minutes to download the model and initial feature data files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = [
+"setuptools>=59.6",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]  # list of folders that contain the packages (["."] by default)
+include = ["mltdm"]  # package names should match these glob patterns (["*"] by default)
+exclude = ["Notebooks"]  # exclude packages matching these glob patterns (empty by default)
+namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+[project]
+name = "mltdm"
+version = "0.1.0"
+description = "Random Forest Thermosphere Density Model"
+authors = [
+	{ name = "Kyle Murphy" },
+	{ name = "Chris Bard" }
+]
+requires-python = ">=3.10,<4.0.0"
+readme = "README.md"
+
+classifiers = [
+"Development Status :: 3 - Alpha",
+"Intended Audience :: Education",
+"Intended Audience :: Science/Research",
+"Programming Language :: Python",
+"Operating System :: OS Independent",
+"Topic :: Scientific/Engineering :: Physics"
+]
+
+dependencies = ['numpy>=1.24.2', 'pandas>=2.2.2', 'matplotlib>=3.7.1', 'scikit-learn ==1.5.1', 'skops ==0.11.0', 'netCDF4 >=1.6.4', 'ipywidgets >=8.1.3', 'tqdm >=4.66.4']

--- a/requirements.md
+++ b/requirements.md
@@ -1,7 +1,0 @@
-netcdf4
-pandas
-numpy
-skops
-
-tdqm
-ipywidgets


### PR DESCRIPTION
I added a pyproject.toml file to MLTDM to allow for local installation of the mltdm repository, i.e. `pip install -e .` . This command also installs all required dependencies for MLTDM. I cleared up the installation and setup instructions in the README. This allows for the module to be imported outside the local directory with `import mltdm`. 

For most of the dependencies, I set the version number to >= what I had on my system. However, I froze `scikit-learn ==1.5.1` and `skops==0.11.0`, since the current MLTDM model was saved using those library versions. I get a warning about loading the model if I use a different library version, e.g. 1.5.2.