### PR TITLE
Fixed pyproject.toml; added missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,19 @@ classifiers = [
 "Topic :: Scientific/Engineering :: Physics"
 ]
 
-dependencies = ['numpy>=1.24.2', 'pandas>=2.2.2', 'matplotlib>=3.7.1', 'scikit-learn ==1.5.1', 'skops ==0.11.0', 'netCDF4 >=1.6.4', 'ipywidgets >=8.1.3', 'tqdm >=4.66.4']
+dependencies = [
+    'numpy>=1.24.2',
+    'pandas>=2.2.2',
+    'matplotlib>=3.7.1',
+    'scikit-learn ==1.5.1',
+    'skops ==0.11.0',
+    'netCDF4 >=1.6.4',
+    'ipywidgets >=8.1.3',
+    'tqdm >=4.66.4',
+    "requests>=2.33.1",
+    "pyyaml>=6.0.0",
+    "scipy>=1.10.0",
+    "python-dateutil>=2.8.2",
+    "cartopy>=0.25.0",
+    "euvpy>=1.0.0"
+]


### PR DESCRIPTION
Updating the pyproject.toml file so that `pip install -e .` works again. Also, this allows ML-TDM to be automatically installed when used with other codebases. 